### PR TITLE
落下処理を実装した

### DIFF
--- a/app/features/game/core/config/configLoader.ts
+++ b/app/features/game/core/config/configLoader.ts
@@ -49,6 +49,17 @@ export const createGameConfig = async (
         // フィールドの寸法
         const fieldWidth = 600;
         const fieldHeight = 400;
+        
+        // 物理世界の境界をフィールドサイズに一致させる（重要）
+        this.physics.world.setBounds(
+          this.cameras.main.centerX - fieldWidth / 2,
+          this.cameras.main.centerY - fieldHeight / 2,
+          fieldWidth,
+          fieldHeight
+        );
+        
+        // 物理境界のデバッグ出力
+        console.log('Physics World Bounds:', this.physics.world.bounds);
 
         // 緑のフィールドを作成
         const field = this.add.rectangle(
@@ -120,6 +131,9 @@ export const createGameConfig = async (
             players.push(enemyPlayer);
           }
           
+          // プレイヤー配列をシーンのデータとして保存（update内で使用するため）
+          this.data.set('playerObjects', players);
+          
           // プレイヤー同士の衝突を設定
           this.physics.add.collider(players, players, (obj1, obj2) => {
             const p1 = obj1 as unknown as Player;
@@ -178,6 +192,20 @@ export const createGameConfig = async (
           }).setOrigin(0, 0).setName(statusTextKey).setDepth(1000);
         } else {
           statusText.setText(`status: ${status}`);
+        }
+
+        // 保存されたプレイヤーオブジェクトを取得
+        const players = this.data.get('playerObjects');
+        
+        // プレイヤーごとの更新処理
+        if (players && Array.isArray(players)) {
+          for (const player of players) {
+            if (player && typeof player.update === 'function') {
+              // プレイヤーのアップデート関数を呼び出し
+              player.update();
+              console.log(`Updating player ${player.id} at (${player.x}, ${player.y})`);
+            }
+          }
         }
       }
     }

--- a/app/features/game/core/objects/player.ts
+++ b/app/features/game/core/objects/player.ts
@@ -12,6 +12,7 @@ export class Player extends GameObjects.Arc {
   public weight: number;
   public volume: number;
   public cd: number;
+  public isAlive: boolean = true;
 
   private isCooldown: boolean = false;
   private moveSpeed: number = 0;
@@ -82,6 +83,7 @@ export class Player extends GameObjects.Arc {
       volume: this.volume,
       cooldown: this.cd,
       position: { x: this.x, y: this.y },
+      isAlive: this.isAlive,
       isActive: true
     });
 
@@ -152,8 +154,6 @@ export class Player extends GameObjects.Arc {
     // 速度ベクトルと速度の大きさを取得
     const myVelocity = new Phaser.Math.Vector2(myBody.velocity.x, myBody.velocity.y);
     const mySpeed = myVelocity.length();
-    const targetVelocity = new Phaser.Math.Vector2(targetBody.velocity.x, targetBody.velocity.y);
-    const targetSpeed = targetVelocity.length();
 
     // 衝突方向ベクトル（自分から相手への方向）
     const collisionVector = new Phaser.Math.Vector2(

--- a/app/features/game/core/state/ClientGameStateManager.ts
+++ b/app/features/game/core/state/ClientGameStateManager.ts
@@ -18,6 +18,8 @@ export interface PlayerState {
   volume: number;
   cooldown: number;
   position: { x: number; y: number };
+  isAlive: boolean;
+  // CD 中かどうか
   isActive: boolean;
 }
 


### PR DESCRIPTION
# Details
<!-- 作業の内容を3行程度で説明 -->
フィールドから落下した際、プレイやーが死亡するように実装しました。
操作プレイヤーが死亡した際は操作が聞かなくなります。

# デバッグ手順
<!-- あなたの作業が成功していることを示すデバッグの手順を記載する -->
<!-- 必ず「どうなれば成功か」を記載すること！！ -->

デバッグページ：https://3ef91dca-58-hack-front.ogata-1225-koroku.workers.dev/debug

## 敵プレイヤーが死亡する
1. 適当な敵プレイヤーをはじき出します
2. 死亡判定（半透明になる）が発生すれば成功です

## 操作プレイヤーが死亡する
1. フィールド外に操作プレイヤーを出します
2. 死亡判定が発生するか確認します
3. ひっぱり操作を行い、反応しないことを確認できれば成功です

<!-- 以下消さないでください！！ -->

<!-- for GitHub Copilot -->
<!-- レビューの際は、必ず以下のコメントに示す条件を満たしてください。 -->
<!-- 1. 日本語を使用すること -->
<!-- 2. 口調は軽快で親しみやすい関西弁にすること。ただし、やや抑えめで読みやすさを優先すること。 -->
<!-- 3. 絵文字を多用すること。絵文字は、前後の文に関係のあるものを添付すること。 -->
<!-- よい例：このプルリクエスト、ホーム画面の改善めっちゃ分かりやすいわ！ヘッダーのデザイン、マジでお洒落やん 🚀✨ -->
<!-- 悪い例：このプルリクエストでは、ホーム画面に変更が加えられています。ヘッダーのスタイルにより顕著な変更が見られます。-->