### PR TITLE
update: homeにモーダル実装, 部屋作成モーダルをバツボタンで閉じるように統一

### DIFF
--- a/app/components/CreateRoomModal.tsx
+++ b/app/components/CreateRoomModal.tsx
@@ -1,0 +1,136 @@
+import type React from "react";
+import { useState } from "react";
+
+interface CreateRoomModalProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+const maxPlayersOptions = [2, 3, 4, 5, 6, 7, 8];
+
+const styles = {
+	overlay: {
+		position: "fixed" as const,
+		top: 0,
+		left: 0,
+		width: "100vw",
+		height: "100vh",
+		background: "rgba(0,0,0,0.3)",
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		zIndex: 1000,
+	},
+	modal: {
+		background: "#fff",
+		borderRadius: "12px",
+		padding: "32px",
+		minWidth: "340px",
+		boxShadow: "0 2px 16px rgba(0,0,0,0.15)",
+		position: "relative" as const,
+	},
+	backButton: {
+		position: "absolute" as const,
+		top: 16,
+		left: 16,
+		background: "none",
+		border: "none",
+		fontSize: "16px",
+		cursor: "pointer",
+		color: "#333",
+	},
+	title: { margin: 0, fontSize: "1.7rem", fontWeight: 700 },
+	subtitle: { color: "#666", marginBottom: 24 },
+	formGroup: { marginBottom: 24 },
+	input: {
+		width: "100%",
+		padding: "10px",
+		border: "1px solid #ddd",
+		borderRadius: "6px",
+		fontSize: "16px",
+		marginTop: 6,
+	},
+	submitButton: {
+		width: "100%",
+		padding: "12px 0",
+		background: "#111",
+		color: "#fff",
+		border: "none",
+		borderRadius: "8px",
+		fontSize: "17px",
+		fontWeight: 600,
+		cursor: "pointer",
+	},
+};
+
+const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ open, onClose }) => {
+	const [roomName, setRoomName] = useState("");
+	const [maxPlayers, setMaxPlayers] = useState(4);
+
+	if (!open) return null;
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		// 部屋作成処理をここに実装
+		onClose();
+	};
+
+	return (
+		<div style={styles.overlay}>
+			<div style={styles.modal}>
+				<button
+					type="button"
+					style={{
+						position: "absolute",
+						top: 16,
+						right: 16,
+						background: "none",
+						border: "none",
+						fontSize: "20px",
+						cursor: "pointer",
+					}}
+					aria-label="閉じる"
+					onClick={onClose}
+				>
+					×
+				</button>
+				<h2 style={styles.title}>部屋を作成</h2>
+				<p style={styles.subtitle}>あいことばを設定して部屋を作成しましょう</p>
+				<form onSubmit={handleSubmit}>
+					<div style={styles.formGroup}>
+						<label htmlFor="roomName">部屋の名前</label>
+						<input
+							type="text"
+							id="roomName"
+							placeholder="例: 楽しいゲーム部屋"
+							value={roomName}
+							onChange={(e) => setRoomName(e.target.value)}
+							style={styles.input}
+							required
+						/>
+					</div>
+					<div style={styles.formGroup}>
+						<label htmlFor="maxPlayers">最大プレイヤー数</label>
+						<select
+							value={maxPlayers}
+							id="maxPlayers"
+							onChange={(e) => setMaxPlayers(Number(e.target.value))}
+							style={styles.input}
+						>
+							{maxPlayersOptions.map((opt) => (
+								<option key={opt} value={opt}>
+									{opt}
+								</option>
+							))}
+						</select>
+					</div>
+					<button type="submit" style={styles.submitButton}>
+						部屋を作成
+					</button>
+				</form>
+			</div>
+		</div>
+	);
+};
+
+export default CreateRoomModal;

--- a/app/components/JoinRoomModal.tsx
+++ b/app/components/JoinRoomModal.tsx
@@ -1,0 +1,113 @@
+import type React from "react";
+import { useState } from "react";
+
+interface JoinRoomModalProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+const JoinRoomModal: React.FC<JoinRoomModalProps> = ({ open, onClose }) => {
+	const [keyword, setKeyword] = useState("");
+	if (!open) return null;
+	return (
+		<div
+			style={{
+				position: "fixed",
+				top: 0,
+				left: 0,
+				width: "100vw",
+				height: "100vh",
+				background: "rgba(0,0,0,0.3)",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				zIndex: 1000,
+			}}
+		>
+			<div
+				style={{
+					background: "#fff",
+					borderRadius: "12px",
+					padding: "32px",
+					minWidth: "340px",
+					boxShadow: "0 2px 16px rgba(0,0,0,0.15)",
+					position: "relative",
+				}}
+			>
+				<button
+					type="button"
+					onClick={onClose}
+					style={{
+						position: "absolute",
+						top: 16,
+						right: 16,
+						background: "none",
+						border: "none",
+						fontSize: "20px",
+						cursor: "pointer",
+					}}
+					aria-label="閉じる"
+				>
+					×
+				</button>
+				<h2 style={{ margin: 0, fontSize: "1.7rem", fontWeight: 700 }}>
+					部屋に参加
+				</h2>
+				<p style={{ color: "#666", marginBottom: 24 }}>
+					あいことばを入力して部屋に参加しましょう
+				</p>
+				<form
+					onSubmit={(e) => {
+						e.preventDefault();
+						// 参加処理をここに実装
+						onClose();
+					}}
+				>
+					<div style={{ marginBottom: 28 }}>
+						<label
+							htmlFor="password"
+							style={{ fontWeight: 600, display: "block", marginBottom: 6 }}
+						>
+							あいことば
+						</label>
+						<input
+							type="text"
+							id="password"
+							placeholder="例: たのしいゲーム"
+							value={keyword}
+							onChange={(e) => setKeyword(e.target.value)}
+							style={{
+								width: "100%",
+								padding: "10px",
+								border: "1px solid #ddd",
+								borderRadius: "6px",
+								fontSize: "16px",
+							}}
+						/>
+						<div style={{ color: "#888", fontSize: "13px", marginTop: 4 }}>
+							部屋に参加するために必要なあいことばを入力してください
+						</div>
+					</div>
+					<button
+						type="submit"
+						style={{
+							width: "100%",
+							padding: "12px 0",
+							background: "#111",
+							color: "#fff",
+							border: "none",
+							borderRadius: "8px",
+							fontSize: "17px",
+							fontWeight: 600,
+							cursor: "pointer",
+						}}
+					>
+						参加する
+					</button>
+				</form>
+			</div>
+		</div>
+	);
+};
+
+export default JoinRoomModal;

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,6 +1,12 @@
+import React, { useState } from "react";
 import RoomCard from "~/components/RoomCard";
+import CreateRoomModal from "../components/CreateRoomModal";
+import JoinRoomModal from "../components/JoinRoomModal";
 
 export default function Home() {
+	const [open, setOpen] = useState(false);
+	const [showModal, setShowModal] = useState(false);
+
 	return (
 		<div className="w-full flex flex-col items-center px-4 md:px-5">
 			{/* メインカード部分 */}
@@ -10,7 +16,7 @@ export default function Home() {
 					description="新しいゲーム部屋を作成して友達を招待しましょう"
 					icon="create"
 					onClick={() => {
-						// TODO: 部屋作成処理
+						setShowModal(true);
 					}}
 				/>
 				<RoomCard
@@ -18,10 +24,12 @@ export default function Home() {
 					description="友達が作成した部屋に参加しましょう"
 					icon="join"
 					onClick={() => {
-						// TODO: 部屋参加処理
+						setOpen(true);
 					}}
 				/>
 			</div>
+			<JoinRoomModal open={open} onClose={() => setOpen(false)} />
+			<CreateRoomModal open={showModal} onClose={() => setShowModal(false)} />
 		</div>
 	);
 }


### PR DESCRIPTION
# Details
<!-- 作業の内容を3行程度で説明 -->
- /homeに雑の人くんが作ってくれたモーダルをいい感じにhomeに合体させた。
- モーダルの閉じ方が「戻る」と「バツボタン」になっていたのでバツボタンに統一した

# デバッグ手順
<!-- あなたの作業が成功していることを示すデバッグの手順を記載する -->
<!-- 必ず「どうなれば成功か」を記載すること！！ -->
- /homeにアクセスして部屋を作成するボタンを押してモーダルが表示されるか確認
- 同様に部屋に参加するボタンを押してモーダルが表示されるか確認
- それぞれのボタンがバツボタンで閉じることができるか確認

# その他
<!-- 以下消さないでください！！ -->

<!-- for GitHub Copilot -->
<!-- レビューの際は、必ず以下のコメントに示す条件を満たしてください。 -->
<!-- 1. 日本語を使用すること -->
<!-- 2. 口調は軽快で親しみやすい関西弁にすること。ただし、やや抑えめで読みやすさを優先すること。 -->
<!-- 3. 絵文字を多用すること。絵文字は、前後の文に関係のあるものを添付すること。 -->
<!-- よい例：このプルリクエスト、ホーム画面の改善めっちゃ分かりやすいわ！ヘッダーのデザイン、マジでお洒落やん 🚀✨ -->
<!-- 悪い例：このプルリクエストでは、ホーム画面に変更が加えられています。ヘッダーのスタイルにより顕著な変更が見られます。-->