### PR TITLE
ゲーム終了時処理を実装した

### DIFF
--- a/app/features/game/components/PhaserGame.tsx
+++ b/app/features/game/components/PhaserGame.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { ClientOnly } from "remix-utils/client-only";
+import { useNavigate } from "@remix-run/react";
 import { createGameConfig } from "../core/config/configLoader";
 import type { GameSettings, PlayerData } from "../core/config/gameSettings";
 
@@ -23,6 +24,23 @@ export default function PhaserGame({
 }: PhaserGameProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const gameInitializedRef = useRef<boolean>(false);
+	const navigate = useNavigate();
+
+	// ゲーム終了時のリダイレクトイベントリスナー
+	useEffect(() => {
+		const handleGameRedirect = () => {
+			console.log("Redirecting to result page");
+			navigate("/result");
+		};
+
+		// イベントリスナーを追加
+		window.addEventListener("gameRedirectToResult", handleGameRedirect);
+
+		// クリーンアップ関数
+		return () => {
+			window.removeEventListener("gameRedirectToResult", handleGameRedirect);
+		};
+	}, [navigate]);
 
 	// Phaserの初期化処理をClientOnlyの外に出し、コンテナ要素が存在する場合のみ実行する
 	const initPhaser = async () => {

--- a/app/features/game/components/PhaserGame.tsx
+++ b/app/features/game/components/PhaserGame.tsx
@@ -1,6 +1,6 @@
+import { useNavigate } from "@remix-run/react";
 import { useEffect, useRef } from "react";
 import { ClientOnly } from "remix-utils/client-only";
-import { useNavigate } from "@remix-run/react";
 import { createGameConfig } from "../core/config/configLoader";
 import type { GameSettings, PlayerData } from "../core/config/gameSettings";
 

--- a/app/features/game/core/config/config.ts
+++ b/app/features/game/core/config/config.ts
@@ -1,24 +1,24 @@
 // display
-export const DISPLAY_WIDTH = 800
-export const DISPLAY_HEIGHT = 600
+export const DISPLAY_WIDTH = 800;
+export const DISPLAY_HEIGHT = 600;
 
 // field
-export const FIELD_WIDTH = 600
-export const FIELD_HEIGHT = 400
+export const FIELD_WIDTH = 600;
+export const FIELD_HEIGHT = 400;
 
 // colors
 export const COLORS = {
-  // background
-  BACKGROUND: "#BBFBFF",
-  
-  // field
-  FIELD: 0x00ff00,  // 緑のフィールド
-  FIELD_BORDER: 0x00ee00,  // フィールド境界線
-  
-  // player
-  PLAYER: 0xff0000,  // メインプレイヤー（赤）
-  ENEMY: 0xffffff,   // 敵プレイヤー（白）
-  
-  // UI
-  UI_TEXT: "#222",   // UI用テキスト色
-}
+	// background
+	BACKGROUND: "#BBFBFF",
+
+	// field
+	FIELD: 0x00ff00, // 緑のフィールド
+	FIELD_BORDER: 0x00ee00, // フィールド境界線
+
+	// player
+	PLAYER: 0xff0000, // メインプレイヤー（赤）
+	ENEMY: 0xffffff, // 敵プレイヤー（白）
+
+	// UI
+	UI_TEXT: "#222", // UI用テキスト色
+};

--- a/app/features/game/core/config/configLoader.ts
+++ b/app/features/game/core/config/configLoader.ts
@@ -238,19 +238,19 @@ export const createGameConfig = async (
 					if (status === "playing") {
 						// 生存プレイヤー数をカウント
 						const alivePlayers = players.filter((player) => player.isAlive);
-
+						
 						// 生存プレイヤーが1名のみになった場合、ゲーム終了
 						if (alivePlayers.length === 1) {
 							// 既にゲーム終了イベントが発生していないことを確認
 							if (!this.data.get("gameFinished")) {
 								console.log("Game finished! Winner:", alivePlayers[0].id);
-
+								
 								// ゲーム終了フラグを立てる
 								this.data.set("gameFinished", true);
-
+								
 								// ゲーム状態を終了に設定
 								stateManager.setGameStatus("finished");
-
+								
 								// 勝者情報を記録
 								stateManager.setWinner(alivePlayers[0].id);
 

--- a/app/features/game/core/config/configLoader.ts
+++ b/app/features/game/core/config/configLoader.ts
@@ -1,7 +1,7 @@
 import type { Player } from "../objects/player";
 import ClientGameStateManager from "../state/ClientGameStateManager";
+import { COLORS, FIELD_HEIGHT, FIELD_WIDTH } from "./config";
 import type { GameSettings } from "./gameSettings";
-import { FIELD_WIDTH, FIELD_HEIGHT, COLORS } from "./config";
 
 const stateManager = ClientGameStateManager.getInstance();
 
@@ -90,55 +90,57 @@ export const createGameConfig = async (
 					// メインプレイヤーが見つかったかどうか追跡する変数
 					let mainPlayer: Player | null = null;
 
-          if(playerDataArray.length === 0) {
-            throw new Error("No player data found. please provide player data.");
-          }
+					if (playerDataArray.length === 0) {
+						throw new Error(
+							"No player data found. please provide player data.",
+						);
+					}
 
-          for (const playerData of playerDataArray) {
-            // プレイヤー位置の決定
-            let x: number;
-            if (playerData.x !== undefined) {
-              x = playerData.x;
-            } else {
-              x = Phaser.Math.Between(
-                this.cameras.main.centerX - FIELD_WIDTH / 2 + 40,
-                this.cameras.main.centerX + FIELD_WIDTH / 2 - 40,
-              );
-            }
+					for (const playerData of playerDataArray) {
+						// プレイヤー位置の決定
+						let x: number;
+						if (playerData.x !== undefined) {
+							x = playerData.x;
+						} else {
+							x = Phaser.Math.Between(
+								this.cameras.main.centerX - FIELD_WIDTH / 2 + 40,
+								this.cameras.main.centerX + FIELD_WIDTH / 2 - 40,
+							);
+						}
 
-            let y: number;
-            if (playerData.y !== undefined) {
-              y = playerData.y;
-            } else {
-              y = Phaser.Math.Between(
-                this.cameras.main.centerY - FIELD_HEIGHT / 2 + 40,
-                this.cameras.main.centerY + FIELD_HEIGHT / 2 - 40,
-              );
-            }
+						let y: number;
+						if (playerData.y !== undefined) {
+							y = playerData.y;
+						} else {
+							y = Phaser.Math.Between(
+								this.cameras.main.centerY - FIELD_HEIGHT / 2 + 40,
+								this.cameras.main.centerY + FIELD_HEIGHT / 2 - 40,
+							);
+						}
 
-            const player = new Player(
-              this,
-              x,
-              y,
-              20, // 半径
-              playerData.id,
-              playerData.icon,
-              playerData.power,
-              playerData.weight,
-              playerData.volume,
-              playerData.cd,
-            );
+						const player = new Player(
+							this,
+							x,
+							y,
+							20, // 半径
+							playerData.id,
+							playerData.icon,
+							playerData.power,
+							playerData.weight,
+							playerData.volume,
+							playerData.cd,
+						);
 
-            // メインプレイヤーは赤色、その他は白色
-            if (playerData.isMainPlayer) {
-              player.setFillStyle(COLORS.PLAYER, 1);
-              mainPlayer = player;
-            } else {
-              player.setFillStyle(COLORS.ENEMY, 1);
-            }
+						// メインプレイヤーは赤色、その他は白色
+						if (playerData.isMainPlayer) {
+							player.setFillStyle(COLORS.PLAYER, 1);
+							mainPlayer = player;
+						} else {
+							player.setFillStyle(COLORS.ENEMY, 1);
+						}
 
-            playerObjects.push(player);
-          }
+						playerObjects.push(player);
+					}
 
 					// プレイヤー配列をシーンのデータとして保存（update内で使用するため）
 					this.data.set("playerObjects", playerObjects);
@@ -231,39 +233,44 @@ export const createGameConfig = async (
 							);
 						}
 					}
-					
+
 					// ゲームが進行中の場合のみ終了判定を行う
 					if (status === "playing") {
 						// 生存プレイヤー数をカウント
 						const alivePlayers = players.filter((player) => player.isAlive);
-						
+
 						// 生存プレイヤーが1名のみになった場合、ゲーム終了
 						if (alivePlayers.length === 1) {
 							// 既にゲーム終了イベントが発生していないことを確認
 							if (!this.data.get("gameFinished")) {
 								console.log("Game finished! Winner:", alivePlayers[0].id);
-								
+
 								// ゲーム終了フラグを立てる
 								this.data.set("gameFinished", true);
-								
+
 								// ゲーム状態を終了に設定
 								stateManager.setGameStatus("finished");
-								
+
 								// 勝者情報を記録
 								stateManager.setWinner(alivePlayers[0].id);
-								
+
 								// GAME SETの表示
 								const gameSetText = this.add
-									.text(this.cameras.main.centerX, this.cameras.main.centerY, "GAME SET", {
-										font: "bold 64px Arial",
-										color: "#FF0000",
-										stroke: "#FFFFFF",
-										strokeThickness: 6,
-										padding: { left: 16, right: 16, top: 8, bottom: 8 },
-									})
+									.text(
+										this.cameras.main.centerX,
+										this.cameras.main.centerY,
+										"GAME SET",
+										{
+											font: "bold 64px Arial",
+											color: "#FF0000",
+											stroke: "#FFFFFF",
+											strokeThickness: 6,
+											padding: { left: 16, right: 16, top: 8, bottom: 8 },
+										},
+									)
 									.setOrigin(0.5, 0.5)
 									.setDepth(2000);
-								
+
 								// テキストアニメーション
 								this.tweens.add({
 									targets: gameSetText,
@@ -274,7 +281,7 @@ export const createGameConfig = async (
 									repeat: 1,
 									ease: "Sine.easeInOut",
 								});
-								
+
 								// 3秒後に結果画面へリダイレクト
 								this.time.delayedCall(3000, () => {
 									// リダイレクトイベントを発火

--- a/app/features/game/core/config/configLoader.ts
+++ b/app/features/game/core/config/configLoader.ts
@@ -231,6 +231,59 @@ export const createGameConfig = async (
 							);
 						}
 					}
+					
+					// ゲームが進行中の場合のみ終了判定を行う
+					if (status === "playing") {
+						// 生存プレイヤー数をカウント
+						const alivePlayers = players.filter((player) => player.isAlive);
+						
+						// 生存プレイヤーが1名のみになった場合、ゲーム終了
+						if (alivePlayers.length === 1) {
+							// 既にゲーム終了イベントが発生していないことを確認
+							if (!this.data.get("gameFinished")) {
+								console.log("Game finished! Winner:", alivePlayers[0].id);
+								
+								// ゲーム終了フラグを立てる
+								this.data.set("gameFinished", true);
+								
+								// ゲーム状態を終了に設定
+								stateManager.setGameStatus("finished");
+								
+								// 勝者情報を記録
+								stateManager.setWinner(alivePlayers[0].id);
+								
+								// GAME SETの表示
+								const gameSetText = this.add
+									.text(this.cameras.main.centerX, this.cameras.main.centerY, "GAME SET", {
+										font: "bold 64px Arial",
+										color: "#FF0000",
+										stroke: "#FFFFFF",
+										strokeThickness: 6,
+										padding: { left: 16, right: 16, top: 8, bottom: 8 },
+									})
+									.setOrigin(0.5, 0.5)
+									.setDepth(2000);
+								
+								// テキストアニメーション
+								this.tweens.add({
+									targets: gameSetText,
+									scaleX: 1.2,
+									scaleY: 1.2,
+									duration: 500,
+									yoyo: true,
+									repeat: 1,
+									ease: "Sine.easeInOut",
+								});
+								
+								// 3秒後に結果画面へリダイレクト
+								this.time.delayedCall(3000, () => {
+									// リダイレクトイベントを発火
+									const event = new CustomEvent("gameRedirectToResult");
+									window.dispatchEvent(event);
+								});
+							}
+						}
+					}
 				}
 			},
 		},

--- a/app/features/game/core/objects/player.ts
+++ b/app/features/game/core/objects/player.ts
@@ -407,6 +407,9 @@ export class Player extends GameObjects.Arc {
 			isAlive: false,
 			isActive: false,
 		});
+		
+		// 脱落プレイヤーとして記録
+		ClientGameStateManager.getInstance().addEliminatedPlayer(this.id);
 
 		// 死亡エフェクトを表示
 		this.showDeathEffect();

--- a/app/features/game/core/objects/player.ts
+++ b/app/features/game/core/objects/player.ts
@@ -1,6 +1,6 @@
 import { GameObjects } from "phaser";
-import ClientGameStateManager from "../state/ClientGameStateManager";
 import { COLORS } from "../config/config";
+import ClientGameStateManager from "../state/ClientGameStateManager";
 
 /**
  * Phaserゲーム内のプレイヤーオブジェクトクラス

--- a/app/features/game/core/state/ClientGameStateManager.ts
+++ b/app/features/game/core/state/ClientGameStateManager.ts
@@ -7,6 +7,7 @@
 export interface GameState {
 	players: Record<string, PlayerState>;
 	gameStatus: "waiting" | "playing" | "finished";
+	winner?: string; // 勝者のID
 }
 
 // プレイヤー状態を定義
@@ -29,6 +30,7 @@ type GameEvent =
 	| { type: "playerUpdated"; player: PlayerState }
 	| { type: "playerRemoved"; playerId: string }
 	| { type: "gameStatusChanged"; status: "waiting" | "playing" | "finished" }
+	| { type: "winnerSet"; winnerId: string }
 	| { type: "stateReset" };
 
 // イベントリスナーの型
@@ -129,6 +131,17 @@ class ClientGameStateManager {
 		this.notifyListeners({
 			type: "gameStatusChanged",
 			status,
+		});
+	}
+
+	/**
+	 * 勝者IDを設定
+	 */
+	public setWinner(winnerId: string): void {
+		this._state.winner = winnerId;
+		this.notifyListeners({
+			type: "winnerSet",
+			winnerId,
 		});
 	}
 

--- a/app/features/game/hooks/useClientGameState.ts
+++ b/app/features/game/hooks/useClientGameState.ts
@@ -33,12 +33,14 @@ export function useClientGameState() {
 				players: {},
 				gameStatus: "waiting",
 				winner: undefined,
+				eliminationOrder: [],
 			} as GameState,
 			addPlayer: () => {},
 			updatePlayer: () => {},
 			removePlayer: () => {},
 			setGameStatus: () => {},
 			setWinner: () => {},
+			addEliminatedPlayer: () => {},
 			resetState: () => {},
 		};
 	}
@@ -55,6 +57,8 @@ export function useClientGameState() {
 			ClientGameStateManager.getInstance().setGameStatus(status),
 		setWinner: (winnerId: string) =>
 			ClientGameStateManager.getInstance().setWinner(winnerId),
+		addEliminatedPlayer: (playerId: string) =>
+			ClientGameStateManager.getInstance().addEliminatedPlayer(playerId),
 		resetState: () => ClientGameStateManager.getInstance().resetState(),
 	};
 }

--- a/app/features/game/hooks/useClientGameState.ts
+++ b/app/features/game/hooks/useClientGameState.ts
@@ -8,19 +8,6 @@ import ClientGameStateManager, {
  * クライアントサイドのゲーム状態を利用するためのカスタムフック
  */
 export function useClientGameState() {
-	// サーバーサイドレンダリング時は空のオブジェクトを返す
-	if (typeof window === "undefined") {
-		return {
-			gameState: { players: {}, gameStatus: "waiting", winner: undefined } as GameState,
-			addPlayer: () => {},
-			updatePlayer: () => {},
-			removePlayer: () => {},
-			setGameStatus: () => {},
-			setWinner: () => {},
-			resetState: () => {},
-		};
-	}
-
 	const [gameState, setGameState] = useState<GameState>(
 		ClientGameStateManager.getInstance().getState(),
 	);
@@ -38,6 +25,23 @@ export function useClientGameState() {
 			gameStateManager.removeEventListener(handleEvent);
 		};
 	}, []);
+
+	// サーバーサイドレンダリング時は空のオブジェクトを返す
+	if (typeof window === "undefined") {
+		return {
+			gameState: {
+				players: {},
+				gameStatus: "waiting",
+				winner: undefined,
+			} as GameState,
+			addPlayer: () => {},
+			updatePlayer: () => {},
+			removePlayer: () => {},
+			setGameStatus: () => {},
+			setWinner: () => {},
+			resetState: () => {},
+		};
+	}
 
 	return {
 		gameState,

--- a/app/features/game/hooks/useClientGameState.ts
+++ b/app/features/game/hooks/useClientGameState.ts
@@ -11,11 +11,12 @@ export function useClientGameState() {
 	// サーバーサイドレンダリング時は空のオブジェクトを返す
 	if (typeof window === "undefined") {
 		return {
-			gameState: { players: {}, gameStatus: "waiting" },
+			gameState: { players: {}, gameStatus: "waiting", winner: undefined } as GameState,
 			addPlayer: () => {},
 			updatePlayer: () => {},
 			removePlayer: () => {},
 			setGameStatus: () => {},
+			setWinner: () => {},
 			resetState: () => {},
 		};
 	}
@@ -48,6 +49,8 @@ export function useClientGameState() {
 			ClientGameStateManager.getInstance().removePlayer(playerId),
 		setGameStatus: (status: "waiting" | "playing" | "finished") =>
 			ClientGameStateManager.getInstance().setGameStatus(status),
+		setWinner: (winnerId: string) =>
+			ClientGameStateManager.getInstance().setWinner(winnerId),
 		resetState: () => ClientGameStateManager.getInstance().resetState(),
 	};
 }

--- a/app/routes/result.tsx
+++ b/app/routes/result.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@remix-run/react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useClientGameState } from "~/features/game/hooks/useClientGameState";
 
 // 型定義
@@ -26,7 +26,7 @@ export default function Result() {
 		if (gameState.winner) {
 			// ゲーム状態から勝者のIDを取得
 			const winnerId = gameState.winner;
-			
+
 			// プレイヤー情報から勝者の名前を取得（もしあれば）
 			const winner = gameState.players[winnerId];
 			if (winner) {

--- a/app/routes/result.tsx
+++ b/app/routes/result.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@remix-run/react";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useClientGameState } from "~/features/game/hooks/useClientGameState";
 
 // 型定義
 interface Results {
@@ -17,6 +18,22 @@ const mockResults: Results[] = [
 
 export default function Result() {
 	const navigate = useNavigate();
+	const { gameState } = useClientGameState();
+	const [winnerName, setWinnerName] = useState("勝者");
+
+	// 勝者情報を取得
+	useEffect(() => {
+		if (gameState.winner) {
+			// ゲーム状態から勝者のIDを取得
+			const winnerId = gameState.winner;
+			
+			// プレイヤー情報から勝者の名前を取得（もしあれば）
+			const winner = gameState.players[winnerId];
+			if (winner) {
+				setWinnerName(winner.id);
+			}
+		}
+	}, [gameState]);
 
 	return (
 		<div className="w-full min-h-screen flex flex-col items-center justify-center bg-white px-4 py-8">
@@ -37,7 +54,7 @@ export default function Result() {
 						d="M12 2a1 1 0 0 1 1 1v2.09A7.001 7.001 0 0 1 19 12a7 7 0 0 1-6 6.93V21h3a1 1 0 1 1 0 2H8a1 1 0 1 1 0-2h3v-2.07A7.001 7.001 0 0 1 5 12a7 7 0 0 1 6-6.91V3a1 1 0 0 1 1-1z"
 					/>
 				</svg>
-				<h2 className="text-xl font-bold mb-1">ホストユーザーの勝利！</h2>
+				<h2 className="text-xl font-bold mb-1">{winnerName}の勝利！</h2>
 				<p className="text-gray-500">おめでとうございます！</p>
 			</div>
 			<div className="w-full max-w-md bg-gray-50 rounded-lg shadow p-4 mb-8">

--- a/app/routes/result.tsx
+++ b/app/routes/result.tsx
@@ -20,17 +20,39 @@ export default function Result() {
 	const navigate = useNavigate();
 	const { gameState } = useClientGameState();
 	const [winnerName, setWinnerName] = useState("勝者");
+	const [results, setResults] = useState<Results[]>([]);
 
-	// 勝者情報を取得
+	// 勝者情報と結果を取得
 	useEffect(() => {
-		if (gameState.winner) {
-			// ゲーム状態から勝者のIDを取得
-			const winnerId = gameState.winner;
-
-			// プレイヤー情報から勝者の名前を取得（もしあれば）
-			const winner = gameState.players[winnerId];
-			if (winner) {
-				setWinnerName(winner.id);
+		if (gameState.eliminationOrder && gameState.eliminationOrder.length > 0) {
+			// 新しい結果配列を作成
+			const newResults: Results[] = [];
+			
+			// 脱落順序から順位を計算（逆順で評価）
+			// eliminationOrderの最初は勝者（1位）、以降は脱落順
+			gameState.eliminationOrder.forEach((playerId, index) => {
+				const player = gameState.players[playerId];
+				const playerName = player?.id || `プレイヤー${index + 1}`;
+				
+				// スコアは単純に順位に応じて設定
+				const score = (gameState.eliminationOrder.length - index) * 100;
+				
+				newResults.push({
+					rank: index + 1,
+					name: playerName,
+					username: `@${playerName.toLowerCase().replace(/\s/g, '_')}`,
+					score: score
+				});
+			});
+			
+			setResults(newResults);
+			
+			// 勝者名も設定
+			if (gameState.winner) {
+				const winner = gameState.players[gameState.winner];
+				if (winner) {
+					setWinnerName(winner.id);
+				}
 			}
 		}
 	}, [gameState]);
@@ -60,11 +82,12 @@ export default function Result() {
 			<div className="w-full max-w-md bg-gray-50 rounded-lg shadow p-4 mb-8">
 				<h3 className="text-lg font-semibold mb-4">最終スコア</h3>
 				<div className="flex flex-col gap-3">
-					{mockResults.map((user) => (
-						<div
-							key={user.rank}
-							className={`flex items-center justify-between rounded-lg px-4 py-3 ${user.rank === 1 ? "bg-yellow-50" : "bg-white"}`}
-						>
+					{results.length > 0 ? (
+						results.map((user) => (
+							<div
+								key={user.rank}
+								className={`flex items-center justify-between rounded-lg px-4 py-3 ${user.rank === 1 ? "bg-yellow-50" : "bg-white"}`}
+							>
 							<div className="flex items-center gap-3">
 								<span
 									className={`w-7 h-7 flex items-center justify-center rounded-full font-bold text-white ${user.rank === 1 ? "bg-yellow-400" : user.rank === 2 ? "bg-gray-300" : "bg-yellow-200 text-gray-700"}`}
@@ -78,7 +101,29 @@ export default function Result() {
 							</div>
 							<span className="text-lg font-bold">{user.score}点</span>
 						</div>
-					))}
+						))
+					) : (
+						// 結果がない場合はモックデータを表示
+						mockResults.map((user) => (
+							<div
+								key={user.rank}
+								className={`flex items-center justify-between rounded-lg px-4 py-3 ${user.rank === 1 ? "bg-yellow-50" : "bg-white"}`}
+							>
+								<div className="flex items-center gap-3">
+									<span
+										className={`w-7 h-7 flex items-center justify-center rounded-full font-bold text-white ${user.rank === 1 ? "bg-yellow-400" : user.rank === 2 ? "bg-gray-300" : "bg-yellow-200 text-gray-700"}`}
+									>
+										{user.rank}
+									</span>
+									<div>
+										<div className="font-semibold">{user.name}</div>
+										<div className="text-xs text-gray-400">{user.username}</div>
+									</div>
+								</div>
+								<span className="text-lg font-bold">{user.score}点</span>
+							</div>
+						))
+					)}
 				</div>
 			</div>
 			<div className="flex gap-4 w-full max-w-md">


### PR DESCRIPTION
# Details
<!-- 作業の内容を3行程度で説明 -->
以下を実装しました。
- プレイヤーが1人のみ生き残った時、その人を勝者とする
- 終了後、`/results` に遷移する
- 終了時の演出（"GAME SET" が表示される）

# デバッグ手順
<!-- あなたの作業が成功していることを示すデバッグの手順を記載する -->
<!-- 必ず「どうなれば成功か」を記載すること！！ -->

1. デバッグページ（`/debug`）を開き、全員倒します
2. "GAME SET" が表示され、数秒後に `/results` にリダイレクトされれば成功です

<!-- 以下消さないでください！！ -->

<!-- for GitHub Copilot -->
<!-- レビューの際は、必ず以下のコメントに示す条件を満たしてください。 -->
<!-- 1. 日本語を使用すること -->
<!-- 2. 口調は軽快で親しみやすい関西弁にすること。ただし、やや抑えめで読みやすさを優先すること。 -->
<!-- 3. 絵文字を多用すること。絵文字は、前後の文に関係のあるものを添付すること。 -->
<!-- よい例：このプルリクエスト、ホーム画面の改善めっちゃ分かりやすいわ！ヘッダーのデザイン、マジでお洒落やん 🚀✨ -->
<!-- 悪い例：このプルリクエストでは、ホーム画面に変更が加えられています。ヘッダーのスタイルにより顕著な変更が見られます。-->